### PR TITLE
[DI-230]: Implement Handling OPTIONS Requests

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/LiabilityController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/LiabilityController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.saliabilitiessandpitapi.controllers
 
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
-import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.{LiabilityAction, MethodNotAllowedAction, NINOValidationAction}
+import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.{LiabilityAction, MethodNotAllowedAction, NINOValidationAction, OptionAllowedAction}
 import uk.gov.hmrc.saliabilitiessandpitapi.service.LiabilityService
 
 import javax.inject.Inject
@@ -30,4 +30,5 @@ class LiabilityController @Inject() (
 )(implicit val controllerComponents: ControllerComponents, val ec: ExecutionContext)
     extends BackendBaseController,
       LiabilityAction,
-      MethodNotAllowedAction
+      MethodNotAllowedAction,
+      OptionAllowedAction

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/OptionAllowedAction.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/OptionAllowedAction.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions
+
+import play.api.mvc.{Action, BaseController, Request, Result, Results}
+import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.OptionAllowedAction._
+
+trait OptionAllowedAction:
+  self: BaseController =>
+
+  val optionsEndpoint: Any => Action[_] = _ => Action(Results.Ok.withAllowHeaders(GET))
+
+object OptionAllowedAction:
+  private final val GET                                   = "GET"
+  extension (result: Result)
+    def withAllowHeaders(allowedMethods: String*): Result =
+      result withHeaders "Allow" -> allowedMethods.mkString(", ")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,8 +1,11 @@
 # microservice specific routes
 
 GET         /liability/nino/:nino       uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityController.getLiabilityByNino(nino: String)
+OPTIONS     /liability/nino/:nino       uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityController.optionsEndpoint(nino: String)
 POST        /liability/nino/:nino       uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityController.methodNotAllowed(nino: String)
 PUT         /liability/nino/:nino       uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityController.methodNotAllowed(nino: String)
 DELETE      /liability/nino/:nino       uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityController.methodNotAllowed(nino: String)
-OPTIONS     /liability/nino/:nino       uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityController.methodNotAllowed(nino: String)
 PATCH       /liability/nino/:nino       uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityController.methodNotAllowed(nino: String)
+HEAD        /liability/nino/:nino       uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityController.methodNotAllowed(nino: String)
+
+


### PR DESCRIPTION
This PR introduces the `OptionAllowedAction` trait to streamline handling OPTIONS HTTP requests in our Play Framework application. This enhancement provides a standardized way to set the "Allow" header for responses to OPTIONS requests, indicating which HTTP methods are supported by the endpoint.