### PR TITLE
[DI-231]:Implement Error Handling from Downstream

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/connectors/LiabilityConnector.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/connectors/LiabilityConnector.scala
@@ -18,8 +18,9 @@ package uk.gov.hmrc.saliabilitiessandpitapi.connectors
 
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
+import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
 import uk.gov.hmrc.saliabilitiessandpitapi.config.AppConfig
-import uk.gov.hmrc.saliabilitiessandpitapi.models.integration.*
+import uk.gov.hmrc.saliabilitiessandpitapi.models.integration.BalanceDetail
 
 import scala.concurrent.Future
 
@@ -29,8 +30,8 @@ trait LiabilityConnector extends WithExecutionContext with Recoverable:
   protected given hc: HeaderCarrier = HeaderCarrier()
   protected given service: String   = config.integrationService
 
-  val fetchAllBalances: String => Future[Seq[BalanceDetail]] = nino =>
+  val fetchAllBalances: String => Future[Either[ErrorResponse, Seq[BalanceDetail]]] = nino =>
     client
       .get(url"$service/balance/$nino")
-      .execute[Seq[BalanceDetail]]
+      .execute[Either[ErrorResponse, Seq[BalanceDetail]]]
       .recoverWith(recoverable)

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/mapper/LiabilityMapper.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/mapper/LiabilityMapper.scala
@@ -16,8 +16,19 @@
 
 package uk.gov.hmrc.saliabilitiessandpitapi.mapper
 
+import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
 import uk.gov.hmrc.saliabilitiessandpitapi.models.LiabilityResponse
+import uk.gov.hmrc.saliabilitiessandpitapi.models.LiabilityResponse.{InternalServerError, Ok}
 import uk.gov.hmrc.saliabilitiessandpitapi.models.integration.BalanceDetail
+import LiabilityMapper._
 
 trait LiabilityMapper:
-  val mapToLiabilityResponse: Seq[BalanceDetail] => LiabilityResponse = LiabilityResponse.Ok.apply
+
+  val mapToLiabilityResponse: Either[ErrorResponse, Seq[BalanceDetail]] => LiabilityResponse = {
+    case Left(errorResponse)   => errorResponse.toLiabilityResponse
+    case Right(balanceDetails) => Ok(balanceDetails)
+  }
+
+object LiabilityMapper:
+  extension (errorResponse: ErrorResponse)
+    inline def toLiabilityResponse: LiabilityResponse = InternalServerError(errorResponse.message)


### PR DESCRIPTION
This PR introduces the Either[ErrorResponse, Seq[BalanceDetail]] error handling to streamline downstream errors requests in our Play Framework application. This enhancement provides a standardized way to handle the failure scenario from backend