### PR TITLE
[DI-231]:Implement Error Handling from Downstream - upgrade to handle either single or sequence of elements from downstream

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/connectors/LiabilityConnector.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/connectors/LiabilityConnector.scala
@@ -24,14 +24,12 @@ import uk.gov.hmrc.saliabilitiessandpitapi.models.integration.BalanceDetail
 
 import scala.concurrent.Future
 
-trait LiabilityConnector extends WithExecutionContext with Recoverable:
-  val config: AppConfig
-  val client: HttpClientV2
+trait LiabilityConnector(using config: AppConfig, client: HttpClientV2) extends WithExecutionContext with Recoverable:
   protected given hc: HeaderCarrier = HeaderCarrier()
   protected given service: String   = config.integrationService
 
-  val fetchAllBalances: String => Future[Either[ErrorResponse, Seq[BalanceDetail]]] = nino =>
+  val fetchAllBalances: String => Future[Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]]] = nino =>
     client
       .get(url"$service/balance/$nino")
-      .execute[Either[ErrorResponse, Seq[BalanceDetail]]]
+      .execute[Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]]]
       .recoverWith(recoverable)

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/connectors/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/connectors/package.scala
@@ -25,4 +25,4 @@ import scala.concurrent.ExecutionContext
 package object connectors:
 
   case class DefaultLiabilityConnector @Inject() (config: AppConfig, client: HttpClientV2, ec: ExecutionContext)
-      extends LiabilityConnector
+      extends LiabilityConnector(using config, client)

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/mapper/LiabilityMapper.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/mapper/LiabilityMapper.scala
@@ -24,9 +24,10 @@ import LiabilityMapper._
 
 trait LiabilityMapper:
 
-  val mapToLiabilityResponse: Either[ErrorResponse, Seq[BalanceDetail]] => LiabilityResponse = {
-    case Left(errorResponse)   => errorResponse.toLiabilityResponse
-    case Right(balanceDetails) => Ok(balanceDetails)
+  val mapToLiabilityResponse: Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]] => LiabilityResponse = {
+    case Left(errorResponse)                 => errorResponse.toLiabilityResponse
+    case Right(single: BalanceDetail)        => Ok(Seq(single))
+    case Right(iterable: Seq[BalanceDetail]) => Ok(iterable)
   }
 
 object LiabilityMapper:


### PR DESCRIPTION
**_Title_**:
Simplify JSON Validation for `BalanceDetail` and `Seq[BalanceDetail]`

**_Summary_**:
This PR simplifies the JSON validation logic for handling `BalanceDetail` and `Seq[BalanceDetail]` by consolidating the validation process into a more concise and readable implementation. Implemented a custom `Reads` for `BalanceDetail | Seq[BalanceDetail]` using improved pattern matching. Additionally enhancements of `mapToLiabilityResponse` to handle the updated union type more effectively.