### PR TITLE
[DI-244]: Write Unit Tests for HttpReads Instance

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/OptionAllowedAction.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/OptionAllowedAction.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions
 
-import play.api.mvc.{Action, BaseController, Request, Result, Results}
-import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.OptionAllowedAction._
+import play.api.mvc.{Action, AnyContent, BaseController, Request, Result, Results}
+import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.OptionAllowedAction.*
 
 trait OptionAllowedAction:
   self: BaseController =>
 
-  val optionsEndpoint: Any => Action[_] = _ => Action(Results.Ok.withAllowHeaders(GET))
+  val optionsEndpoint: Any => Action[AnyContent] = _ => Action(Results.Ok.withAllowHeaders(GET))
 
 object OptionAllowedAction:
   private final val GET                                   = "GET"

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorResponse.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorResponse.scala
@@ -22,8 +22,8 @@ import play.api.libs.json.Json.*
 import play.api.mvc.Codec
 
 enum LiabilityErrorResponse(val errorCode: String, val errorDescription: String):
-  case InvalidInputNino extends LiabilityErrorResponse("1113", "Invalid NINO format.")
-  case NinoNotFound extends LiabilityErrorResponse("1002", "NINO not found.")
+  case InvalidInputNino extends LiabilityErrorResponse("1113", "Invalid NINO format")
+  case NinoNotFound extends LiabilityErrorResponse("1002", "NINO not found")
 
 object LiabilityErrorResponse:
   given OWrites[LiabilityErrorResponse]                                  = OWrites { response =>

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/LiabilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/LiabilityControllerSpec.scala
@@ -38,10 +38,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class LiabilityControllerSpec extends AnyWordSpec with Matchers:
 
+  private val service: LiabilityService = mock[LiabilityService]
+  private val getLiabilityFunction      = mock[String => Future[LiabilityResponse]]
+
+  private given ec: ExecutionContext = components.executionContext
+
   private given components: ControllerComponents = Helpers.stubControllerComponents()
-  private given ec: ExecutionContext             = components.executionContext
-  private val service: LiabilityService          = mock[LiabilityService]
-  private val getLiabilityFunction               = mock[String => Future[LiabilityResponse]]
 
   "GET /liability/nino/:nino endpoint" should {
 
@@ -70,7 +72,7 @@ class LiabilityControllerSpec extends AnyWordSpec with Matchers:
   }
 
 private object LiabilityControllerSpec:
+  private val invalidInputNino: LiabilityResponse = Ok(Seq())
+
   object method:
     val GET = "GET"
-
-  private val invalidInputNino: LiabilityResponse = Ok(Seq())

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/MethodNotAllowedActionSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/MethodNotAllowedActionSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import play.api.mvc.*
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.MethodNotAllowedActionSpec.TestController
+
+class MethodNotAllowedActionSpec extends AnyFunSuite, Matchers:
+
+  private val controller = new TestController()
+  given ActorSystem      = ActorSystem("test-system")
+
+  test("methodNotAllowed should return MethodNotAllowed response with correct message") {
+    val request      = FakeRequest(GET, "/test")
+    val expectedJson = Json.obj("description" -> "Method Not Allowed")
+
+    val result = (controller methodNotAllowed "dummy")(request)
+
+    status(result) shouldEqual METHOD_NOT_ALLOWED
+    contentType(result) shouldEqual Some("application/json")
+    contentAsJson(result) shouldEqual expectedJson
+  }
+
+private object MethodNotAllowedActionSpec:
+  class TestController extends BaseController with MethodNotAllowedAction:
+    override def controllerComponents: ControllerComponents = stubControllerComponents()

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationActionSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationActionSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import play.api.mvc.*
+import play.api.mvc.Results.*
+import play.api.test.Helpers.*
+import play.api.test.{FakeRequest, Injecting}
+import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.NINOValidationActionSpec.TestController
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class NINOValidationActionSpec extends AnyFunSuite, Matchers {
+
+  private val controller: TestController = TestController()
+
+  test("Valid NINO should pass validation") {
+    val validNino = "AB123456C"
+    val request   = FakeRequest(GET, s"/path/$validNino")
+    val result    = (controller testAction validNino)(request)
+
+    status(result) shouldEqual OK
+    contentAsString(result) shouldEqual "Valid NINO"
+  }
+
+  test("Invalid NINO should return BadRequest with correct JSON error response") {
+    val invalidNino = "AB12345"
+    val request     = FakeRequest(GET, s"/path/$invalidNino")
+    val result      = (controller testAction invalidNino)(request)
+
+    status(result) shouldEqual BAD_REQUEST
+
+    val expectedJson = Json.parse("""{"errorCode":"1113","errorDescription":"Invalid NINO format"}""")
+    val actualJson   = contentAsJson(result)
+
+    actualJson shouldEqual expectedJson
+  }
+
+  test("Request without NINO should return BadRequest with correct JSON error response") {
+    val request = FakeRequest(GET, "/path/")
+    val result  = (controller testAction "invalid")(request)
+
+    status(result) shouldEqual BAD_REQUEST
+
+    val expectedJson = Json.parse("""{"errorCode":"1113","errorDescription":"Invalid NINO format"}""")
+    val actualJson   = contentAsJson(result)
+
+    actualJson shouldEqual expectedJson
+  }
+}
+
+private object NINOValidationActionSpec:
+  class TestController(
+    val controllerComponents: ControllerComponents = stubControllerComponents(),
+    val executionContext: ExecutionContext = stubControllerComponents().executionContext
+  ) extends BaseController
+      with NINOValidationAction:
+
+    def testAction(path: String): Action[AnyContent] = Action.async(filter(_).map {
+      case Some(result) => result
+      case None         => Ok("Valid NINO")
+    })

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/OptionAllowedActionSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/OptionAllowedActionSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.mvc.*
+import play.api.test.*
+import play.api.test.Helpers.*
+import uk.gov.hmrc.saliabilitiessandpitapi.controllers.LiabilityControllerSpec.method.GET
+import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.OptionAllowedActionSpec.controller
+
+import scala.concurrent.Future
+
+class OptionAllowedActionSpec extends AnyFunSuite, Matchers:
+
+  test("OptionAllowedAction should add Allow headers to the result") {
+    val request = FakeRequest(GET, "/liability/nino/QQ123456A")
+
+    val result: Future[Result] = (controller optionsEndpoint "dummy")(request)
+
+    status(result) shouldBe OK
+    headers(result)  should contain("Allow" -> "GET")
+  }
+
+private object OptionAllowedActionSpec:
+  val controller: OptionAllowedAction & BaseController = new OptionAllowedAction with BaseController:
+    override def controllerComponents: ControllerComponents = stubControllerComponents()

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorHandlerSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.http
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
+import play.api.libs.json.Json.toJson
+import play.api.mvc.{AnyContentAsEmpty, Result}
+import play.api.test.Helpers.*
+import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import uk.gov.hmrc.play.bootstrap.config.HttpAuditEvent
+import uk.gov.hmrc.saliabilitiessandpitapi.http.LiabilityErrorResponse.{InvalidInputNino, NinoNotFound}
+import uk.gov.hmrc.saliabilitiessandpitapi.http.LiabilityHttpException.{InvalidPathParametersException, NinoNotFoundException}
+
+import scala.concurrent.Future
+
+class LiabilityErrorHandlerSpec extends AnyFunSuite, MockitoSugar, Matchers:
+
+  val errorHandler: LiabilityErrorHandler = new LiabilityErrorHandler(
+    auditConnector = mock[AuditConnector],
+    httpAuditEvent = mock[HttpAuditEvent],
+    configuration = mock[Configuration]
+  )(stubControllerComponents().executionContext)
+
+  val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+
+  test("should handle NinoNotFoundException and return the correct result") {
+    val exception              = NinoNotFoundException()
+    val expectedResult         = toJson(NinoNotFound).toString
+    val result: Future[Result] = errorHandler.onServerError(request, exception)
+
+    status(result)          shouldBe 400
+    contentAsString(result) shouldBe expectedResult
+  }
+
+  test("should delegate unknown exceptions to the superclass handler") {
+    val exception = new RuntimeException("Unknown error")
+
+    val result: Future[Result] = errorHandler.onServerError(request, exception)
+
+    status(result) shouldBe 500
+    assert(contentAsString(result).contains("Unknown error"))
+  }
+
+  test("should handle InvalidPathParametersException and return the correct result") {
+    val exception      = InvalidPathParametersException()
+    val expectedResult = toJson(InvalidInputNino).toString
+
+    val result: Future[Result] = errorHandler.onServerError(request, exception)
+
+    status(result)          shouldBe 400
+    contentAsString(result) shouldBe expectedResult
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorResponseSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorResponseSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.http
+
+import org.scalatest.funsuite.AnyFunSuite
+import play.api.libs.json.Json
+import uk.gov.hmrc.saliabilitiessandpitapi.http.LiabilityErrorResponse.*
+
+class LiabilityErrorResponseSpec extends AnyFunSuite:
+
+  test("InvalidInputNino should have correct errorCode and errorDescription") {
+    val response = InvalidInputNino
+
+    assert(response.errorCode == "1113")
+    assert(response.errorDescription == "Invalid NINO format")
+  }
+
+  test("NinoNotFound should have correct errorCode and errorDescription") {
+    val response = NinoNotFound
+
+    assert(response.errorCode == "1002")
+    assert(response.errorDescription == "NINO not found")
+  }
+
+  test("InvalidInputNino should serialize to correct JSON") {
+    val response = InvalidInputNino
+
+    val json = Json.toJson(response)
+
+    assert((json \ "errorCode").as[String] == "1113")
+    assert((json \ "errorDescription").as[String] == "Invalid NINO format")
+  }
+
+  test("NinoNotFound should serialize to correct JSON") {
+    val response = NinoNotFound
+
+    val json = Json.toJson(response)
+
+    assert((json \ "errorCode").as[String] == "1002")
+    assert((json \ "errorDescription").as[String] == "NINO not found")
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityHttpExceptionSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityHttpExceptionSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.http
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import uk.gov.hmrc.saliabilitiessandpitapi.http.LiabilityHttpException.{InvalidPathParametersException, NinoNotFoundException}
+
+class LiabilityHttpExceptionSpec extends AnyFunSuite, Matchers:
+
+  test("InvalidPathParametersException should have correct message and responseCode") {
+    val exception = InvalidPathParametersException()
+
+    exception.message shouldEqual "Invalid NINO format received."
+    exception.responseCode shouldEqual 400
+  }
+
+  test("NinoNotFoundException should have correct message and responseCode") {
+    val exception = NinoNotFoundException()
+
+    exception.message shouldEqual "The provided NINO was not found in the system."
+    exception.responseCode shouldEqual 400
+
+  }
+
+  test("InvalidPathParametersException should allow custom message and responseCode") {
+    val customMessage      = "Custom error message"
+    val customResponseCode = 404
+
+    val exception = InvalidPathParametersException(message = customMessage, responseCode = customResponseCode)
+
+    exception.message shouldEqual customMessage
+    exception.responseCode shouldEqual customResponseCode
+  }
+
+  test("NinoNotFoundException should allow custom message and responseCode") {
+    val customMessage      = "Custom NINO not found message"
+    val customResponseCode = 404
+
+    val exception = NinoNotFoundException(message = customMessage, responseCode = customResponseCode)
+
+    exception.message shouldEqual customMessage
+    exception.responseCode shouldEqual customResponseCode
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/json/JsonSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/json/JsonSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.json
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.*
+
+class JsonSpec extends AnyFunSuite with Matchers:
+
+  test("bigDecimalBasedWrites should correctly convert T to BigDecimal") {
+    case class Foo(value: Int)
+    val exampleWrites: Writes[Foo] = bigDecimalBasedWrites(_.value)
+
+    val result = Json.toJson(Foo(123))(exampleWrites).as[BigDecimal]
+
+    result shouldEqual BigDecimal(123)
+  }
+
+  test("bigDecimalBasedReads should correctly read BigDecimal from JsValue") {
+    val bigDecimalReads: Reads[BigDecimal] = bigDecimalBasedReads
+    val json                               = Json.toJson(BigDecimal(123.45))
+
+    val result = json.validate[BigDecimal](bigDecimalReads).getOrElse(BigDecimal(0))
+
+    result shouldEqual BigDecimal(123.45)
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/mapper/LiabilityMapperSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/mapper/LiabilityMapperSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.mapper
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
+import uk.gov.hmrc.saliabilitiessandpitapi.http.LiabilityHttpException.NinoNotFoundException
+import uk.gov.hmrc.saliabilitiessandpitapi.models.*
+import uk.gov.hmrc.saliabilitiessandpitapi.models.integration.BalanceDetail
+
+class LiabilityMapperSpec extends AnyFunSuite, Matchers, MockitoSugar:
+
+  val TestLiabilityMapper: LiabilityMapper = new LiabilityMapper {}
+
+  test("mapToLiabilityResponse should throw NinoNotFoundException for Left(ErrorResponse)") {
+    val errorResponse: Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]] = Left(mock[ErrorResponse])
+
+    an[NinoNotFoundException] should be thrownBy TestLiabilityMapper.mapToLiabilityResponse(errorResponse)
+
+  }
+
+  test("mapToLiabilityResponse should return Ok with single BalanceDetail") {
+    val balance                                                             = BalanceDetail(
+      payableAmount = PayableAmount(100.00),
+      payableDueDate = PayableDueDate("2024-07-20"),
+      pendingDueAmount = PendingDueAmount(100.02),
+      pendingDueDate = PendingDueDate("2024-08-20"),
+      overdueAmount = OverdueAmount(100.03),
+      totalBalance = TotalBalance(300.5)
+    )
+    val response: Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]] = Right(balance)
+    val expectedResult                                                      = LiabilityResponse.Ok(Seq(balance))
+
+    val result = TestLiabilityMapper.mapToLiabilityResponse(response)
+
+    result shouldEqual expectedResult
+  }
+
+  test("mapToLiabilityResponse should return Ok with a sequence of BalanceDetail") {
+    val balances                                                            = Seq(
+      BalanceDetail(
+        payableAmount = PayableAmount(100.00),
+        payableDueDate = PayableDueDate("2024-07-20"),
+        pendingDueAmount = PendingDueAmount(100.02),
+        pendingDueDate = PendingDueDate("2024-08-20"),
+        overdueAmount = OverdueAmount(100.03),
+        totalBalance = TotalBalance(300.5)
+      ),
+      BalanceDetail(
+        payableAmount = PayableAmount(200.00),
+        payableDueDate = PayableDueDate("2024-08-20"),
+        pendingDueAmount = PendingDueAmount(200.02),
+        pendingDueDate = PendingDueDate("2024-09-20"),
+        overdueAmount = OverdueAmount(200.03),
+        totalBalance = TotalBalance(600.5)
+      )
+    )
+    val expectedResult                                                      = LiabilityResponse.Ok(balances)
+    val response: Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]] = Right(balances)
+
+    val result = TestLiabilityMapper.mapToLiabilityResponse(response)
+
+    result shouldEqual expectedResult
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/models/BalanceDetailSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/models/BalanceDetailSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.models
+
+import org.mockito.Mockito.when
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.libs.json.*
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
+import uk.gov.hmrc.saliabilitiessandpitapi.models.*
+import uk.gov.hmrc.saliabilitiessandpitapi.models.BalanceDetailSpec.*
+import uk.gov.hmrc.saliabilitiessandpitapi.models.integration.*
+
+object BalanceDetailSpec:
+  val balanceDetailJson: JsValue = Json.parse("""
+    {
+      "totalBalance":300.5,
+      "pendingDueDate":"2024-08-20",
+      "pendingDueAmount":100.02,
+      "payableAmount":100,
+      "overdueAmount":100.03,
+      "payableDueDate":"2024-07-20"
+    }
+  """)
+
+  val balanceDetail: BalanceDetail = BalanceDetail(
+    payableAmount = PayableAmount(BigDecimal(100.00)),
+    payableDueDate = PayableDueDate("2024-07-20"),
+    pendingDueAmount = PendingDueAmount(BigDecimal(100.02)),
+    pendingDueDate = PendingDueDate("2024-08-20"),
+    overdueAmount = OverdueAmount(BigDecimal(100.03)),
+    totalBalance = TotalBalance(BigDecimal(300.5))
+  )
+
+class BalanceDetailSpec extends AnyFunSuite with Matchers:
+
+  test("BalanceDetail should be serialized to JSON correctly") {
+    val json = Json.toJson(balanceDetail)
+
+    json shouldEqual balanceDetailJson
+  }
+
+  test("BalanceDetail should be deserialized from JSON correctly") {
+    val result = balanceDetailJson.validate[BalanceDetail]
+    result shouldEqual JsSuccess(balanceDetail)
+  }
+
+  test("Reads should handle single BalanceDetail and Seq[BalanceDetail] correctly") {
+    val singleJson = Json.toJson(balanceDetail)
+    val seqJson    = Json.toJson(Seq(balanceDetail))
+
+    singleJson.validate[BalanceDetail | Seq[BalanceDetail]] shouldEqual JsSuccess(balanceDetail)
+    seqJson.validate[BalanceDetail | Seq[BalanceDetail]] shouldEqual JsSuccess(Seq(balanceDetail))
+
+    val invalidJson = Json.parse("""{ "invalid": "data" }""")
+    invalidJson.validate[BalanceDetail | Seq[BalanceDetail]] shouldBe a[JsError]
+  }
+
+  test("HttpReads should parse successful response with BalanceDetail") {
+    val response = mock[HttpResponse]
+    when(response.status).thenReturn(200)
+    when(response.json).thenReturn(balanceDetailJson)
+
+    val result = implicitly[HttpReads[Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]]]]
+      .read("GET", "foo", response)
+
+    result shouldEqual Right(balanceDetail)
+  }
+
+  test("HttpReads should parse successful response with Seq[BalanceDetail]") {
+    val seqJson  = Json.toJson(Seq(balanceDetail))
+    val response = mock[HttpResponse]
+    when(response.status).thenReturn(200)
+    when(response.json).thenReturn(seqJson)
+
+    val result = implicitly[HttpReads[Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]]]]
+      .read("GET", "foo", response)
+
+    result shouldEqual Right(Seq(balanceDetail))
+  }
+
+  test("HttpReads should parse error response") {
+    val errorResponseJson = Json.parse("""{ "status": 400, "message": "Bad Request" }""")
+    val response          = mock[HttpResponse]
+    when(response.status).thenReturn(400)
+    when(response.json).thenReturn(errorResponseJson)
+
+    val result = implicitly[HttpReads[Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]]]]
+      .read("GET", "foo", response)
+
+    result shouldEqual Left(
+      ErrorResponse(
+        400,
+        "Error parsing response",
+        Some("List((/statusCode,List(JsonValidationError(List(error.path.missing),ArraySeq()))))"),
+        None
+      )
+    )
+  }
+
+  test("HttpReads should handle parse error response") {
+    val invalidJson = Json.parse("""{ "invalid": "data" }""")
+    val response    = mock[HttpResponse]
+    when(response.status).thenReturn(400)
+    when(response.json).thenReturn(invalidJson)
+
+    val result = implicitly[HttpReads[Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]]]]
+      .read("GET", "foo", response)
+
+    result shouldEqual Left(
+      ErrorResponse(
+        400,
+        "Error parsing response",
+        Some(
+          "List((/message,List(JsonValidationError(List(error.path.missing),ArraySeq()))), (/statusCode,List(JsonValidationError(List(error.path.missing),ArraySeq()))))"
+        ),
+        None
+      )
+    )
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/models/LiabilityResponseSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/models/LiabilityResponseSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.models
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.http.{ContentTypeOf, ContentTypes, Writeable}
+import play.api.libs.json.*
+import play.api.mvc.Codec
+import uk.gov.hmrc.saliabilitiessandpitapi.models.*
+import uk.gov.hmrc.saliabilitiessandpitapi.models.LiabilityResponse.*
+import uk.gov.hmrc.saliabilitiessandpitapi.models.LiabilityResponseSpec.*
+import uk.gov.hmrc.saliabilitiessandpitapi.models.integration.*
+
+object LiabilityResponseSpec:
+
+  val balanceDetail: BalanceDetail = BalanceDetail(
+    PayableAmount(BigDecimal(100.00)),
+    PayableDueDate("2024-07-20"),
+    PendingDueAmount(BigDecimal(100.02)),
+    PendingDueDate("2024-08-20"),
+    OverdueAmount(BigDecimal(100.03)),
+    TotalBalance(BigDecimal(300.5))
+  )
+
+  val okResponse: LiabilityResponse               = Ok(Seq(balanceDetail))
+  val methodNotAllowedResponse: LiabilityResponse = MethodNotAllowed("Method not allowed")
+
+class LiabilityResponseSpec extends AnyFunSuite with Matchers {
+
+  test("LiabilityResponse.Ok should serialize to JSON correctly") {
+    val expectedJson = Json.parse("""
+        |{
+        |  "balances": [
+        |    {
+        |      "payableAmount": 100.00,
+        |      "payableDueDate": "2024-07-20",
+        |      "pendingDueAmount": 100.02,
+        |      "pendingDueDate": "2024-08-20",
+        |      "overdueAmount": 100.03,
+        |      "totalBalance": 300.5
+        |    }
+        |  ]
+        |}
+      """.stripMargin)
+
+    Json.toJson(okResponse) shouldEqual expectedJson
+  }
+
+  test("LiabilityResponse.MethodNotAllowed should serialize to JSON correctly") {
+    val expectedJson = Json.parse("""
+        |{
+        |  "description": "Method not allowed"
+        |}
+      """.stripMargin)
+
+    Json.toJson(methodNotAllowedResponse) shouldEqual expectedJson
+  }
+
+  test("ContentTypeOf for LiabilityResponse should be JSON") {
+    val contentType = implicitly[ContentTypeOf[LiabilityResponse]]
+
+    contentType shouldEqual ContentTypeOf(Some(ContentTypes.JSON))
+  }
+
+  test("Writeable for LiabilityResponse should serialize data correctly") {
+    implicit val codec: Codec = Codec.utf_8
+
+    val jsonString = Json.toJson(okResponse).toString()
+    val writeable  = implicitly[Writeable[LiabilityResponse]]
+    val result     = writeable.transform(okResponse).utf8String
+
+    result shouldEqual jsonString
+  }
+}

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/models/ModelsSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/models/ModelsSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.models
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.*
+import uk.gov.hmrc.saliabilitiessandpitapi.models.*
+
+class ModelsSpec extends AnyFunSuite with Matchers:
+
+  test("PendingDueDate should serialize and deserialize correctly") {
+    val date: PendingDueDate = PendingDueDate("2024-08-20")
+    val json                 = Json.toJson(date)
+    val expectedJson         = JsString("2024-08-20")
+
+    json shouldEqual expectedJson
+    json.as[PendingDueDate] shouldEqual date
+  }
+
+  test("PayableDueDate should serialize and deserialize correctly") {
+    val date: PayableDueDate = PayableDueDate("2024-07-20")
+    val json                 = Json.toJson(date)
+    val expectedJson         = JsString("2024-07-20")
+
+    json shouldEqual expectedJson
+    json.as[PayableDueDate] shouldEqual date
+  }
+
+  test("TotalBalance should serialize and deserialize correctly") {
+    val balance: TotalBalance = TotalBalance(BigDecimal(300.50))
+    val json                  = Json.toJson(balance)
+    val expectedJson          = JsNumber(300.50)
+
+    json shouldEqual expectedJson
+    json.as[TotalBalance] shouldEqual balance
+  }
+
+  test("PayableAmount should serialize and deserialize correctly") {
+    val amount: PayableAmount = PayableAmount(BigDecimal(100.00))
+    val json                  = Json.toJson(amount)
+    val expectedJson          = JsNumber(100.00)
+
+    json shouldEqual expectedJson
+    json.as[PayableAmount] shouldEqual amount
+  }
+
+  test("PendingDueAmount should serialize and deserialize correctly") {
+    val amount: PendingDueAmount = PendingDueAmount(BigDecimal(100.02))
+    val json                     = Json.toJson(amount)
+    val expectedJson             = JsNumber(100.02)
+
+    json shouldEqual expectedJson
+    json.as[PendingDueAmount] shouldEqual amount
+  }
+
+  test("OverdueAmount should serialize and deserialize correctly") {
+    val amount: OverdueAmount = OverdueAmount(BigDecimal(100.03))
+    val json                  = Json.toJson(amount)
+    val expectedJson          = JsNumber(100.03)
+
+    json shouldEqual expectedJson
+    json.as[OverdueAmount] shouldEqual amount
+  }


### PR DESCRIPTION
This pull request introduces a comprehensive suite of tests for the Actions and related components in the uk.gov.hmrc.saliabilitiessandpitapi project. The tests cover various aspects of functionality including validation actions, configuration handling, and response handling. The focus is on ensuring that our actions and services correctly interact and handle edge cases as expected.


**How to Test**
- Run All Tests: Execute all tests using your build tool (e.g., sbt test) to verify that all scenarios pass as expected