### PR TITLE
[DI-252]: Implement CorrelationId Header in 400 Responses

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/http/ErrorResultCreator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/http/ErrorResultCreator.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.http
+
+import play.api.mvc.Result
+import play.api.mvc.Results.Status
+import uk.gov.hmrc.saliabilitiessandpitapi.http.HeaderNames.correlationId
+
+import java.util.UUID.randomUUID
+
+object ErrorResultCreator extends (Int => LiabilityErrorResponse => Result):
+
+  override inline def apply(statusCode: Int): LiabilityErrorResponse => Result =
+    Status(statusCode)(_) withHeaders correlationId -> randomUUID().toString

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/http/HeaderNames.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/http/HeaderNames.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.http
+
+object HeaderNames:
+  val correlationId = "CorrelationId"

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorHandler.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorHandler.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.saliabilitiessandpitapi.http
 
 import play.api.Configuration
-import play.api.mvc.Results.*
-import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.{RequestHeader, Result, Results}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler
 import uk.gov.hmrc.play.bootstrap.config.HttpAuditEvent
@@ -45,5 +44,5 @@ class LiabilityErrorHandler @Inject() (
 private object LiabilityErrorHandler:
   extension (liabilityHttpException: LiabilityHttpException)
     inline def toResult: Result = liabilityHttpException match
-      case NinoNotFoundException(message, responseCode)          => new Status(responseCode)(NinoNotFound)
-      case InvalidPathParametersException(message, responseCode) => new Status(responseCode)(InvalidInputNino)
+      case NinoNotFoundException(message, responseCode)          => ErrorResultCreator(responseCode)(NinoNotFound)
+      case InvalidPathParametersException(message, responseCode) => ErrorResultCreator(responseCode)(InvalidInputNino)

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/http/ErrorResultCreatorTestSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/http/ErrorResultCreatorTestSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitapi.http
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.mvc.Result
+import uk.gov.hmrc.saliabilitiessandpitapi.http.LiabilityErrorResponse.NinoNotFound
+
+import java.*
+import java.util.UUID
+import java.util.UUID.fromString
+
+class ErrorResultCreatorTestSpec extends AnyFunSuite, Matchers:
+
+  test("LiabilityStatus should create a Result with the correct status code") {
+    val statusCode: Int                       = 400
+    val errorResponse: LiabilityErrorResponse = NinoNotFound
+
+    val result: Result = ErrorResultCreator(statusCode)(errorResponse)
+
+    result.header.status shouldEqual statusCode
+  }
+
+  test("LiabilityStatus should include a CorrelationId header in the Result") {
+    val statusCode: Int                       = 400
+    val errorResponse: LiabilityErrorResponse = NinoNotFound
+
+    val result: Result = ErrorResultCreator(statusCode)(errorResponse)
+
+    result.header.headers get "CorrelationId" match
+      case Some(correlationId: String) => fromString(correlationId) shouldBe a[UUID]
+      case None                        => fail("CorrelationId header is missing")
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorHandlerSpec.scala
@@ -50,6 +50,14 @@ class LiabilityErrorHandlerSpec extends AnyFunSuite, MockitoSugar, Matchers:
     contentAsString(result) shouldBe expectedResult
   }
 
+  test("should add a CorrelationId header to the result") {
+    val exception              = NinoNotFoundException()
+    val result: Future[Result] = errorHandler.onServerError(request, exception)
+
+    status(result)                      shouldBe 400
+    headers(result) get "CorrelationId" shouldBe defined
+  }
+
   test("should delegate unknown exceptions to the superclass handler") {
     val exception = new RuntimeException("Unknown error")
 


### PR DESCRIPTION
Add `ErrorResultCreator` Trait for Generating Error Responses

This PR introduces a new trait, `ErrorResultCreator`, which provides a convenient way to generate HTTP Result objects based on error responses and status codes. This functionality is designed to streamline the creation of error responses with consistent headers, including a `CorrelationId` for tracking and diagnostics.
