### PR TITLE
[DI-267]: Dev Hub - Playground API publish - include endpoint security

### DIFF
--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -18,6 +18,18 @@ components:
         type: string
         format: uuid
 
+  securitySchemes:
+    User-Restricted:
+      type: oauth2
+      description: HMRC supports OAuth 2.0 for authenticating [User-restricted](https://developer.service.hmrc.gov.uk/api-documentation/docs/authorisation/user-restricted-endpoints) API requests
+      flows:
+        authorizationCode:
+          authorizationUrl: https://api.service.hmrc.gov.uk/oauth/authorize
+          tokenUrl: https://api.service.hmrc.gov.uk/oauth/token
+          refreshUrl: https://api.service.hmrc.gov.uk/oauth/refresh
+          scopes:
+            read:self-assessment: Grant read access
+
   parameters:
     nino:
       name: NINO
@@ -142,3 +154,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - User-Restricted:
+            - read:self-assessment


### PR DESCRIPTION
This pull request introduces OAuth 2.0 security scheme configuration to the SA Liabilities API. The implementation ensures that all API requests to access Self Assessment (SA) liabilities payment details are authenticated via HMRC's OAuth 2.0 protocol, specifically targeting user-restricted endpoints.