### PR TITLE
[DI-316]: Update Exception messages

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorResponse.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorResponse.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.Json.*
 import play.api.mvc.Codec
 
 enum LiabilityErrorResponse(val errorCode: String, val errorDescription: String):
-  case InvalidInputNino extends LiabilityErrorResponse("1113", "Invalid NINO format")
+  case InvalidInputNino extends LiabilityErrorResponse("1113", "Invalid path parameters")
   case NinoNotFound extends LiabilityErrorResponse("1002", "NINO not found")
 
 object LiabilityErrorResponse:

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityHttpException.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityHttpException.scala
@@ -27,11 +27,11 @@ sealed trait LiabilityHttpException extends RuntimeException with NoStackTrace:
 
 object LiabilityHttpException:
   case class InvalidPathParametersException(
-    message: String = "Invalid NINO format received.",
+    message: String = "Invalid path parameters",
     responseCode: Int = BAD_REQUEST
   ) extends LiabilityHttpException
 
   case class NinoNotFoundException(
-    message: String = "The provided NINO was not found in the system.",
+    message: String = "NINO not found",
     responseCode: Int = BAD_REQUEST
   ) extends LiabilityHttpException

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/LiabilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/LiabilityControllerSpec.scala
@@ -64,7 +64,7 @@ class LiabilityControllerSpec extends AnyWordSpec, Matchers:
       verify(service.getLiability)("QQ123456A")
     }
 
-    "returns 400 for invalid NINO format" in {
+    "returns 400 for invalid NINO" in {
       given request: Request[AnyContentAsEmpty.type] = FakeRequest(GET, "/liability/INVALID")
       given authAction: AuthAction                   = SuccessfulAuthorisation
       given validation: NINOValidationAction         = FailingNINOValidationAction
@@ -73,7 +73,7 @@ class LiabilityControllerSpec extends AnyWordSpec, Matchers:
       val result: Future[Result] = controller.getLiabilityByNino("INVALID")(request)
 
       status(result)        shouldBe Status.BAD_REQUEST
-      contentAsString(result) should include("Invalid NINO format")
+      contentAsString(result) should include("Invalid path parameters")
     }
 
     "returns 400 for insufficient enrolments" in {

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationActionSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationActionSpec.scala
@@ -48,7 +48,7 @@ class NINOValidationActionSpec extends AnyFunSuite, Matchers {
 
     status(result) shouldEqual BAD_REQUEST
 
-    val expectedJson = Json.parse("""{"errorCode":"1113","errorDescription":"Invalid NINO format"}""")
+    val expectedJson = Json.parse("""{"errorCode":"1113","errorDescription":"Invalid path parameters"}""")
     val actualJson   = contentAsJson(result)
 
     actualJson shouldEqual expectedJson
@@ -60,7 +60,7 @@ class NINOValidationActionSpec extends AnyFunSuite, Matchers {
 
     status(result) shouldEqual BAD_REQUEST
 
-    val expectedJson = Json.parse("""{"errorCode":"1113","errorDescription":"Invalid NINO format"}""")
+    val expectedJson = Json.parse("""{"errorCode":"1113","errorDescription":"Invalid path parameters"}""")
     val actualJson   = contentAsJson(result)
 
     actualJson shouldEqual expectedJson

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/stubs/NINOValidationActionStubs.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/stubs/NINOValidationActionStubs.scala
@@ -35,4 +35,4 @@ object NINOValidationActionStubs:
 
   case object FailingNINOValidationAction extends MockedNINOValidationAction:
     override protected def filter[A](request: Request[A]): Future[Option[Result]] =
-      successful(Some(Results BadRequest obj("error" -> "Invalid NINO format.")))
+      successful(Some(Results BadRequest obj("error" -> "Invalid path parameters")))

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorResponseSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorResponseSpec.scala
@@ -26,7 +26,7 @@ class LiabilityErrorResponseSpec extends AnyFunSuite:
     val response = InvalidInputNino
 
     assert(response.errorCode == "1113")
-    assert(response.errorDescription == "Invalid NINO format")
+    assert(response.errorDescription == "Invalid path parameters")
   }
 
   test("NinoNotFound should have correct errorCode and errorDescription") {
@@ -42,7 +42,7 @@ class LiabilityErrorResponseSpec extends AnyFunSuite:
     val json = Json.toJson(response)
 
     assert((json \ "errorCode").as[String] == "1113")
-    assert((json \ "errorDescription").as[String] == "Invalid NINO format")
+    assert((json \ "errorDescription").as[String] == "Invalid path parameters")
   }
 
   test("NinoNotFound should serialize to correct JSON") {

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityHttpExceptionSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityHttpExceptionSpec.scala
@@ -25,14 +25,14 @@ class LiabilityHttpExceptionSpec extends AnyFunSuite, Matchers:
   test("InvalidPathParametersException should have correct message and responseCode") {
     val exception = InvalidPathParametersException()
 
-    exception.message shouldEqual "Invalid NINO format received."
+    exception.message shouldEqual "Invalid path parameters"
     exception.responseCode shouldEqual 400
   }
 
   test("NinoNotFoundException should have correct message and responseCode") {
     val exception = NinoNotFoundException()
 
-    exception.message shouldEqual "The provided NINO was not found in the system."
+    exception.message shouldEqual "NINO not found"
     exception.responseCode shouldEqual 400
   }
 


### PR DESCRIPTION
Tests were failing due to a mismatch in the exception messages provided by the sampler API and the messages required in the spec. This branch addresses these issues in the code and allows for the sampler API to provide the correct exception messages.