### PR TITLE
[DI-318]: Update service to use correct NINO regex

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/auth/NinoFromPathExtractor.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/auth/NinoFromPathExtractor.scala
@@ -27,4 +27,4 @@ trait NinoFromPathExtractor:
     NinoPattern findFirstMatchIn request.path map (_ group 1)
 
 private[this] object NinoFromPathExtractor extends NinoFromPathExtractor:
-  private val NinoPattern: Regex = """.*/nino/([A-Z]{2}\d{6}[A-Z]).*""".r
+  private val NinoPattern: Regex = """.*/nino/([A-Z]{2}[0-9]{6}[A-Z]{0,1}$)""".r

--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationAction.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationAction.scala
@@ -33,7 +33,7 @@ trait NINOValidationAction extends ActionFilter[Request]:
   }
 
 private object NINOValidationAction:
-  private final val ninoPattern = "^[A-Z]{2}[0-9]{6}[A-D]{1}$".r
+  private final val ninoPattern = "^[A-Z]{2}[0-9]{6}[A-Z]{0,1}$".r
   private final val BAD_REQUEST = Results.BadRequest(InvalidInputNino)
 
   extension (request: Request[_]) {

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -37,7 +37,7 @@ components:
       description: The National Insurance Number that is the subject of the request
       schema:
         type: string
-        pattern: '^[A-Z]{2}[0-9]{6}[A-Z]$'
+        pattern: '^[A-Z]{2}[0-9]{6}[A-Z]{0,1}$'
       required: true
 
   schemas:

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/auth/AuthorisationPredicateSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/auth/AuthorisationPredicateSpec.scala
@@ -25,64 +25,68 @@ import uk.gov.hmrc.auth.core.{Enrolment, Nino}
 
 class AuthorisationPredicateSpec extends AnyWordSpec, Matchers, AuthorisationPredicate, NinoFromPathExtractor:
 
-  "AuthorisationPredicate" should:
+  "AuthorisationPredicate" should {
 
-    "generate a predicate with a valid NINO" in:
+    "generate a predicate with a valid NINO" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/QQ123456A")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-      
+    }
 
-    "generate a predicate with no NINO when not present in the path" in:
+    "generate a predicate with no NINO when not present in the path" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/other/path")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
-    
+    }
 
-    "generate a predicate with None NINO when the NINO is invalid" in:
+    "generate a predicate with None NINO when the NINO is invalid" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/INVALID")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
+    }
 
-    "handle a POST request with a valid NINO in the path" in:
+    "handle a POST request with a valid NINO in the path" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("POST", "/nino/QQ123456A")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-    
+    }
 
-    "generate a predicate correctly when request path contains query parameters" in:
+    "generate a predicate correctly when request path contains query parameters" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/QQ123456A?param=value")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-    
+    }
 
-    "generate a predicate with None NINO when NINO is in the path but does not match the expected pattern" in:
+    "generate a predicate with None NINO when NINO is in the path but does not match the expected pattern" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/ABC123456")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
-    
+    }
 
-    "handle request paths with NINO at the end" in:
+    "handle request paths with NINO at the end" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/path/nino/QQ123456A")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-    
+    }
 
-    "generate a predicate with None NINO when the path is empty" in:
+    "generate a predicate with None NINO when the path is empty" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
-    
-    "generate a predicate with None NINO when the path contains only special characters" in:
+    }
+
+    "generate a predicate with None NINO when the path contains only special characters" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/@@@/!!!/###")
-      val predicateResult = predicate(request)
+      val predicateResult                          = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
+    }
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/auth/AuthorisationPredicateSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/auth/AuthorisationPredicateSpec.scala
@@ -25,85 +25,64 @@ import uk.gov.hmrc.auth.core.{Enrolment, Nino}
 
 class AuthorisationPredicateSpec extends AnyWordSpec, Matchers, AuthorisationPredicate, NinoFromPathExtractor:
 
-  "AuthorisationPredicate" should {
+  "AuthorisationPredicate" should:
 
-    "generate a predicate with a valid NINO" in {
+    "generate a predicate with a valid NINO" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/QQ123456A")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-    }
+      
 
-    "generate a predicate with no NINO when not present in the path" in {
+    "generate a predicate with no NINO when not present in the path" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/other/path")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
-    }
+    
 
-    "generate a predicate with None NINO when the NINO is invalid" in {
+    "generate a predicate with None NINO when the NINO is invalid" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/INVALID")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
-    }
 
-    "handle request paths with multiple segments and extract a valid NINO" in {
-      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nino/QQ123456A/details")
-
-      val predicateResult = predicate(request)
-
-      predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-    }
-
-    "handle a POST request with a valid NINO in the path" in {
+    "handle a POST request with a valid NINO in the path" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("POST", "/nino/QQ123456A")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-    }
+    
 
-    "generate a predicate correctly when request path contains query parameters" in {
+    "generate a predicate correctly when request path contains query parameters" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/QQ123456A?param=value")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-    }
+    
 
-    "generate a predicate with None NINO when NINO is in the path but does not match the expected pattern" in {
+    "generate a predicate with None NINO when NINO is in the path but does not match the expected pattern" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/ABC123456")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
-    }
+    
 
-    "handle request paths with NINO at the end" in {
+    "handle request paths with NINO at the end" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/path/nino/QQ123456A")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, Some("QQ123456A")))
-    }
+    
 
-    "generate a predicate with None NINO when the path is empty" in {
+    "generate a predicate with None NINO when the path is empty" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
-    }
-
-    "generate a predicate with None NINO when the path contains only special characters" in {
+    
+    "generate a predicate with None NINO when the path contains only special characters" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/@@@/!!!/###")
-
       val predicateResult = predicate(request)
 
       predicateResult shouldBe (Enrolment("IR-SA") and Nino(hasNino = true, None))
-    }
-  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/auth/NinoFromPathExtractorSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/auth/NinoFromPathExtractorSpec.scala
@@ -23,57 +23,61 @@ import play.api.test.FakeRequest
 
 class NinoFromPathExtractorSpec extends AnyWordSpec, Matchers, NinoFromPathExtractor:
 
-  "NinoFromPathExtractor" should:
+  "NinoFromPathExtractor" should {
 
-    "extract a valid NINO from the request path" in:
+    "extract a valid NINO from the request path" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/QQ123456A")
-      val nino: Option[String] = extractNinoFromRequest(request)
+      val nino: Option[String]                     = extractNinoFromRequest(request)
 
       nino shouldBe Some("QQ123456A")
+    }
 
-
-    "extract a NINO even if the request method is different" in:
+    "extract a NINO even if the request method is different" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("POST", "/nino/QQ123456A")
-      val nino: Option[String] = extractNinoFromRequest(request)
+      val nino: Option[String]                     = extractNinoFromRequest(request)
 
       nino shouldBe Some("QQ123456A")
+    }
 
-
-    "return None when the request path contains an invalid NINO" in :
+    "return None when the request path contains an invalid NINO" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/INVALID")
-      val nino: Option[String] = extractNinoFromRequest(request)
+      val nino: Option[String]                     = extractNinoFromRequest(request)
 
       nino shouldBe None
+    }
 
-
-    "return None when the request path does not contain a NINO" in:
+    "return None when the request path does not contain a NINO" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/other/path")
-      val nino: Option[String] = extractNinoFromRequest(request)
+      val nino: Option[String]                     = extractNinoFromRequest(request)
 
       nino shouldBe None
+    }
 
-    "return None when the path is correct but the NINO is missing" in :
+    "return None when the path is correct but the NINO is missing" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nino/")
-      val nino: Option[String] = extractNinoFromRequest(request)
+      val nino: Option[String]                     = extractNinoFromRequest(request)
 
       nino shouldBe None
+    }
 
-    "return none when NINO is nested within the path" in:
+    "return none when NINO is nested within the path" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nino/QQ123456A/baz")
-      val nino: Option[String] = extractNinoFromRequest(request)
+      val nino: Option[String]                     = extractNinoFromRequest(request)
 
       nino shouldBe None
+    }
 
-
-    "return None when valid NINO is nested within text" in:
+    "return None when valid NINO is nested within text" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/abcQQ123456Axyz")
-      val nino: Option[String] = extractNinoFromRequest(request)
+      val nino: Option[String]                     = extractNinoFromRequest(request)
 
       nino shouldBe None
+    }
 
-
-    "return None when the path contains similar segments but no NINO" in:
+    "return None when the path contains similar segments but no NINO" in {
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nninoo/QQ123456A")
-      val nino: Option[String] = extractNinoFromRequest(request)
+      val nino: Option[String]                     = extractNinoFromRequest(request)
 
       nino shouldBe None
+    }
+  }

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/auth/NinoFromPathExtractorSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/auth/NinoFromPathExtractorSpec.scala
@@ -23,77 +23,57 @@ import play.api.test.FakeRequest
 
 class NinoFromPathExtractorSpec extends AnyWordSpec, Matchers, NinoFromPathExtractor:
 
-  "NinoExtractor" should {
+  "NinoFromPathExtractor" should:
 
-    "extract a valid NINO from the request path" in {
+    "extract a valid NINO from the request path" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/QQ123456A")
-
       val nino: Option[String] = extractNinoFromRequest(request)
 
       nino shouldBe Some("QQ123456A")
-    }
 
-    "return None when the request path does not contain a NINO" in {
-      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/other/path")
 
-      val nino: Option[String] = extractNinoFromRequest(request)
-
-      nino shouldBe None
-    }
-
-    "return None when the request path contains an invalid NINO" in {
-      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/INVALID")
-
-      val nino: Option[String] = extractNinoFromRequest(request)
-
-      nino shouldBe None
-    }
-
-    "extract a NINO from a request path that contains additional parameters" in {
-      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/QQ123456A/details")
-
-      val nino: Option[String] = extractNinoFromRequest(request)
-
-      nino shouldBe Some("QQ123456A")
-    }
-
-    "extract a NINO even if the request method is different" in {
+    "extract a NINO even if the request method is different" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("POST", "/nino/QQ123456A")
-
       val nino: Option[String] = extractNinoFromRequest(request)
 
       nino shouldBe Some("QQ123456A")
-    }
 
-    "extract a NINO from a deeply nested path" in {
-      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nino/QQ123456A/baz")
 
+    "return None when the request path contains an invalid NINO" in :
+      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/INVALID")
       val nino: Option[String] = extractNinoFromRequest(request)
 
-      nino shouldBe Some("QQ123456A")
-    }
+      nino shouldBe None
 
-    "extract a NINO from a path with multiple segments before and after the NINO" in {
-      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nino/QQ123456A/details/more")
 
+    "return None when the request path does not contain a NINO" in:
+      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/other/path")
       val nino: Option[String] = extractNinoFromRequest(request)
 
-      nino shouldBe Some("QQ123456A")
-    }
+      nino shouldBe None
 
-    "return None when the path is correct but the NINO is missing" in {
+    "return None when the path is correct but the NINO is missing" in :
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nino/")
-
       val nino: Option[String] = extractNinoFromRequest(request)
 
       nino shouldBe None
-    }
 
-    "return None when the path contains similar segments but no NINO" in {
+    "return none when NINO is nested within the path" in:
+      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nino/QQ123456A/baz")
+      val nino: Option[String] = extractNinoFromRequest(request)
+
+      nino shouldBe None
+
+
+    "return None when valid NINO is nested within text" in:
+      val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/nino/abcQQ123456Axyz")
+      val nino: Option[String] = extractNinoFromRequest(request)
+
+      nino shouldBe None
+
+
+    "return None when the path contains similar segments but no NINO" in:
       val request: Request[AnyContentAsEmpty.type] = FakeRequest("GET", "/foo/bar/nninoo/QQ123456A")
-
       val nino: Option[String] = extractNinoFromRequest(request)
 
       nino shouldBe None
-    }
-  }


### PR DESCRIPTION
Update the service, tests and OAS to use the correct NINO regex to prevent false positive NINO groups.