### PR TITLE
[DI-317]: Update service to provide a CorrelationId when NINO validation fails

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationAction.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationAction.scala
@@ -16,8 +16,10 @@
 
 package uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions
 
+import play.api.http.Status.BAD_REQUEST
 import play.api.mvc.{ActionFilter, Request, Result, Results}
 import uk.gov.hmrc.saliabilitiessandpitapi.controllers.actions.NINOValidationAction.*
+import uk.gov.hmrc.saliabilitiessandpitapi.http.ErrorResultCreator
 import uk.gov.hmrc.saliabilitiessandpitapi.http.LiabilityErrorResponse.InvalidInputNino
 
 import scala.concurrent.Future
@@ -28,13 +30,13 @@ trait NINOValidationAction extends ActionFilter[Request]:
   override protected def filter[A](request: Request[A]): Future[Option[Result]] = successful {
     request.lastSegment match {
       case Some(input: String) if ninoPattern matches input => None
-      case _                                                => Some(BAD_REQUEST)
+      case _                                                => Some(InvalidInputNinoResult)
     }
   }
 
 private object NINOValidationAction:
-  private final val ninoPattern = "^[A-Z]{2}[0-9]{6}[A-Z]{0,1}$".r
-  private final val BAD_REQUEST = Results.BadRequest(InvalidInputNino)
+  private final val ninoPattern            = "^[A-Z]{2}[0-9]{6}[A-Z]{0,1}$".r
+  private final val InvalidInputNinoResult = ErrorResultCreator(BAD_REQUEST)(InvalidInputNino)
 
   extension (request: Request[_]) {
     private def lastSegment: Option[String] = request.path

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationActionSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/controllers/actions/NINOValidationActionSpec.scala
@@ -47,6 +47,7 @@ class NINOValidationActionSpec extends AnyFunSuite, Matchers {
     val result      = (controller testAction invalidNino)(request)
 
     status(result) shouldEqual BAD_REQUEST
+    headers(result) get "CorrelationId" shouldBe defined
 
     val expectedJson = Json.parse("""{"errorCode":"1113","errorDescription":"Invalid path parameters"}""")
     val actualJson   = contentAsJson(result)

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/http/LiabilityErrorHandlerSpec.scala
@@ -55,7 +55,15 @@ class LiabilityErrorHandlerSpec extends AnyFunSuite, MockitoSugar, Matchers:
     contentAsString(result) shouldBe expectedResult
   }
 
-  test("should add a CorrelationId header to the result") {
+  test("should add a CorrelationId header to the InvalidPathParametersException result") {
+    val exception              = InvalidPathParametersException()
+    val result: Future[Result] = errorHandler.onServerError(request, exception)
+
+    status(result)                      shouldBe 400
+    headers(result) get "CorrelationId" shouldBe defined
+  }
+
+  test("should add a CorrelationId header to the NinoNotFoundException result") {
     val exception              = NinoNotFoundException()
     val result: Future[Result] = errorHandler.onServerError(request, exception)
 


### PR DESCRIPTION
This PR addresses the lack of a CorrelationId in the response headers during the negative scenario where NINO validation fails