### PR TITLE
[DI-321]: Update BalanceDetail to support Optional fields

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitapi/models/integration/BalanceDetail.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitapi/models/integration/BalanceDetail.scala
@@ -17,21 +17,25 @@
 package uk.gov.hmrc.saliabilitiessandpitapi.models.integration
 
 import play.api.http.Status
-import play.api.libs.json.*
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
 import uk.gov.hmrc.saliabilitiessandpitapi.models.*
 
+import scala.annotation.tailrec
+
 case class BalanceDetail(
   payableAmount: PayableAmount,
-  payableDueDate: PayableDueDate,
+  payableDueDate: Option[PayableDueDate],
   pendingDueAmount: PendingDueAmount,
-  pendingDueDate: PendingDueDate,
+  pendingDueDate: Option[PendingDueDate],
   overdueAmount: OverdueAmount,
-  totalBalance: TotalBalance
+  totalBalance: Option[TotalBalance]
 )
 
 object BalanceDetail:
+
   extension (status: Int) private inline def isSuccessful: Boolean = Status.isSuccessful(status)
 
   given Format[BalanceDetail] = Json.format[BalanceDetail]

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/mapper/LiabilityMapperSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/mapper/LiabilityMapperSpec.scala
@@ -35,11 +35,11 @@ class LiabilityMapperSpec extends AnyFunSuite, Matchers, MockitoSugar, Liability
   test("mapToLiabilityResponse should return Ok with single BalanceDetail") {
     val balance                                                             = BalanceDetail(
       payableAmount = PayableAmount(100.00),
-      payableDueDate = PayableDueDate("2024-07-20"),
+      payableDueDate = Some(PayableDueDate("2024-07-20")),
       pendingDueAmount = PendingDueAmount(100.02),
-      pendingDueDate = PendingDueDate("2024-08-20"),
+      pendingDueDate = Some(PendingDueDate("2024-08-20")),
       overdueAmount = OverdueAmount(100.03),
-      totalBalance = TotalBalance(300.5)
+      totalBalance = Some(TotalBalance(300.5))
     )
     val response: Either[ErrorResponse, BalanceDetail | Seq[BalanceDetail]] = Right(balance)
     val expectedResult                                                      = LiabilityResponse.Ok(Seq(balance))
@@ -53,19 +53,19 @@ class LiabilityMapperSpec extends AnyFunSuite, Matchers, MockitoSugar, Liability
     val balances                                                            = Seq(
       BalanceDetail(
         payableAmount = PayableAmount(100.00),
-        payableDueDate = PayableDueDate("2024-07-20"),
+        payableDueDate = Some(PayableDueDate("2024-07-20")),
         pendingDueAmount = PendingDueAmount(100.02),
-        pendingDueDate = PendingDueDate("2024-08-20"),
+        pendingDueDate = Some(PendingDueDate("2024-08-20")),
         overdueAmount = OverdueAmount(100.03),
-        totalBalance = TotalBalance(300.5)
+        totalBalance = Some(TotalBalance(300.5))
       ),
       BalanceDetail(
         payableAmount = PayableAmount(200.00),
-        payableDueDate = PayableDueDate("2024-08-20"),
+        payableDueDate = Some(PayableDueDate("2024-08-20")),
         pendingDueAmount = PendingDueAmount(200.02),
-        pendingDueDate = PendingDueDate("2024-09-20"),
+        pendingDueDate = Some(PendingDueDate("2024-09-20")),
         overdueAmount = OverdueAmount(200.03),
-        totalBalance = TotalBalance(600.5)
+        totalBalance = Some(TotalBalance(600.5))
       )
     )
     val expectedResult                                                      = LiabilityResponse.Ok(balances)

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/models/BalanceDetailSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/models/BalanceDetailSpec.scala
@@ -39,26 +39,54 @@ object BalanceDetailSpec:
     }
   """)
 
+  val minBalanceDetailJson: JsValue = Json.parse("""
+    {
+      "pendingDueAmount":100.02,
+      "payableAmount":100,
+      "overdueAmount":100.03
+    }
+  """)
+
   val balanceDetail: BalanceDetail = BalanceDetail(
     payableAmount = PayableAmount(BigDecimal(100.00)),
-    payableDueDate = PayableDueDate("2024-07-20"),
+    payableDueDate = Some(PayableDueDate("2024-07-20")),
     pendingDueAmount = PendingDueAmount(BigDecimal(100.02)),
-    pendingDueDate = PendingDueDate("2024-08-20"),
+    pendingDueDate = Some(PendingDueDate("2024-08-20")),
     overdueAmount = OverdueAmount(BigDecimal(100.03)),
-    totalBalance = TotalBalance(BigDecimal(300.5))
+    totalBalance = Some(TotalBalance(BigDecimal(300.5)))
+  )
+
+  val minBalanceDetail: BalanceDetail = BalanceDetail(
+    payableAmount = PayableAmount(BigDecimal(100.00)),
+    None,
+    pendingDueAmount = PendingDueAmount(BigDecimal(100.02)),
+    None,
+    overdueAmount = OverdueAmount(BigDecimal(100.03)),
+    None
   )
 
 class BalanceDetailSpec extends AnyFunSuite, Matchers:
 
-  test("BalanceDetail should be serialized to JSON correctly") {
+  test("Optional BalanceDetail should be serialized to JSON correctly") {
     val json = Json.toJson(balanceDetail)
 
     json shouldEqual balanceDetailJson
   }
 
-  test("BalanceDetail should be deserialized from JSON correctly") {
+  test("Optional BalanceDetail should be deserialized from JSON correctly") {
     val result = balanceDetailJson.validate[BalanceDetail]
     result shouldEqual JsSuccess(balanceDetail)
+  }
+
+  test("Required BalanceDetail should be serialized to JSON correctly") {
+    val json = Json.toJson(minBalanceDetail)
+
+    json shouldEqual minBalanceDetailJson
+  }
+
+  test("Required BalanceDetail should be deserialized from JSON correctly") {
+    val result = minBalanceDetailJson.validate[BalanceDetail]
+    result shouldEqual JsSuccess(minBalanceDetail)
   }
 
   test("Reads should handle single BalanceDetail and Seq[BalanceDetail] correctly") {
@@ -120,11 +148,8 @@ class BalanceDetailSpec extends AnyFunSuite, Matchers:
 
     result shouldEqual JsError(
       List(
-        (JsPath \ "totalBalance", List(JsonValidationError("error.path.missing"))),
         (JsPath \ "overdueAmount", List(JsonValidationError("error.path.missing"))),
-        (JsPath \ "pendingDueDate", List(JsonValidationError("error.path.missing"))),
         (JsPath \ "pendingDueAmount", List(JsonValidationError("error.path.missing"))),
-        (JsPath \ "payableDueDate", List(JsonValidationError("error.path.missing"))),
         (JsPath \ "payableAmount", List(JsonValidationError("error.path.missing")))
       )
     )

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/models/LiabilityResponseSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/models/LiabilityResponseSpec.scala
@@ -30,11 +30,11 @@ object LiabilityResponseSpec:
 
   val balanceDetail: BalanceDetail = BalanceDetail(
     PayableAmount(BigDecimal(100.00)),
-    PayableDueDate("2024-07-20"),
+    Some(PayableDueDate("2024-07-20")),
     PendingDueAmount(BigDecimal(100.02)),
-    PendingDueDate("2024-08-20"),
+    Some(PendingDueDate("2024-08-20")),
     OverdueAmount(BigDecimal(100.03)),
-    TotalBalance(BigDecimal(300.5))
+    Some(TotalBalance(BigDecimal(300.5)))
   )
 
   val okResponse: LiabilityResponse               = Ok(Seq(balanceDetail))

--- a/test/uk/gov/hmrc/saliabilitiessandpitapi/service/LiabilityServiceSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitapi/service/LiabilityServiceSpec.scala
@@ -109,11 +109,11 @@ class LiabilityServiceSpec
 private[this] object LiabilityServiceSpec:
   val balanceDetail: BalanceDetail = BalanceDetail(
     payableAmount = PayableAmount(BigDecimal(100.00)),
-    payableDueDate = PayableDueDate("2024-07-20"),
+    payableDueDate = Some(PayableDueDate("2024-07-20")),
     pendingDueAmount = PendingDueAmount(BigDecimal(100.02)),
-    pendingDueDate = PendingDueDate("2024-08-20"),
+    pendingDueDate = Some(PendingDueDate("2024-08-20")),
     overdueAmount = OverdueAmount(BigDecimal(100.03)),
-    totalBalance = TotalBalance(BigDecimal(300.5))
+    totalBalance = Some(TotalBalance(BigDecimal(300.5)))
   )
 
   val mockLiabilityResponse: LiabilityResponse  = LiabilityResponse.Ok(Seq(balanceDetail))


### PR DESCRIPTION
Update BalanceDetail to support Optional fields to match the spec.

Below are the fields:
  payableAmount    (required)
  payableDueDate   (optional)
  pendingDueAmount (required)
  overdueAmount    (required)
  totalBalance     (optional)

