### PR TITLE
[DI-379]: Remove scope from API definition

### DIFF
--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -1,5 +1,4 @@
 {
-  "scopes": [],
   "api": {
     "name": "Self Assessment Liabilities",
     "description": "An API to retrieve Self Assessment Liabilities payment details",


### PR DESCRIPTION
Scope needs to be updated to comply with the following confluence link:

https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=928220471